### PR TITLE
Use jsonapi.org syntax for errors with the included syntax

### DIFF
--- a/example/serializers.py
+++ b/example/serializers.py
@@ -21,7 +21,29 @@ class BlogSerializer(serializers.ModelSerializer):
         meta_fields = ('copyright',)
 
 
-class EntrySerializer(serializers.ModelSerializer):
+class AuthorBioSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = AuthorBio
+        fields = ('author', 'body',)
+
+
+class AuthorSerializer(serializers.ModelSerializer):
+    included_serializers = {
+        'bio': AuthorBioSerializer
+    }
+
+    class Meta:
+        model = Author
+        fields = ('name', 'email', 'bio')
+
+
+class IncludedEntrySerializer(serializers.IncludedResourcesMixin, serializers.Serializer):
+    blogs = BlogSerializer(many=True, required=False)
+    authors = AuthorSerializer(many=True, required=False)
+
+
+class EntrySerializer(serializers.IncludingResourcesMixin, serializers.ModelSerializer):
 
     def __init__(self, *args, **kwargs):
         # to make testing more concise we'll only output the
@@ -36,6 +58,7 @@ class EntrySerializer(serializers.ModelSerializer):
         'comments': 'example.serializers.CommentSerializer',
         'featured': 'example.serializers.EntrySerializer',
     }
+    _included = IncludedEntrySerializer(write_only=True)
 
     body_format = serializers.SerializerMethodField()
     # many related from model
@@ -60,25 +83,8 @@ class EntrySerializer(serializers.ModelSerializer):
     class Meta:
         model = Entry
         fields = ('blog', 'headline', 'body_text', 'pub_date', 'mod_date',
-                  'authors', 'comments', 'featured', 'suggested',)
+                  'authors', 'comments', 'featured', 'suggested', '_included')
         meta_fields = ('body_format',)
-
-
-class AuthorBioSerializer(serializers.ModelSerializer):
-
-    class Meta:
-        model = AuthorBio
-        fields = ('author', 'body',)
-
-
-class AuthorSerializer(serializers.ModelSerializer):
-    included_serializers = {
-        'bio': AuthorBioSerializer
-    }
-
-    class Meta:
-        model = Author
-        fields = ('name', 'email', 'bio')
 
 
 class CommentSerializer(serializers.ModelSerializer):

--- a/requirements-development.txt
+++ b/requirements-development.txt
@@ -1,7 +1,7 @@
 -e .
-pytest==2.8.2
+pytest==2.9
 pytest-django
 pytest-factoryboy
-fake-factory
+fake-factory==0.7.4
 tox
 mock

--- a/rest_framework_json_api/utils.py
+++ b/rest_framework_json_api/utils.py
@@ -283,6 +283,25 @@ class Hyperlink(six.text_type):
     is_hyperlink = True
 
 
+def _format_nested_error(obj, source, **kwargs):
+    errors = []
+    if isinstance(obj, dict):
+        for field, value in obj.items():
+            errors.extend(_format_nested_error(value, source='%s/%s' % (source, field),
+                                              **kwargs))
+    elif isinstance(obj, list):
+        for value in obj:
+            errors.extend(_format_nested_error(value, source=source, **kwargs))
+    else:
+        errors.append(dict({
+            'detail': obj,
+            'meta': {
+                'source': source,
+            },
+        }, **kwargs))
+    return errors
+
+
 def format_drf_errors(response, context, exc):
     errors = []
     # handle generic errors. ValidationError('test') in a view for example
@@ -302,7 +321,20 @@ def format_drf_errors(response, context, exc):
             pointer = '/data/attributes/{}'.format(field)
             # see if they passed a dictionary to ValidationError manually
             if isinstance(error, dict):
-                errors.append(error)
+                if field == '-included':
+                    for type, nested_errors in error.items():
+                        for index, nested_error in enumerate(nested_errors):
+                            try:
+                                identifier = '%s/%s' % (type, context['request'].data['_included'][type][index]['id'])
+                            except KeyError, IndexError:
+                                identifier = '%s' % type
+                            errors.extend(_format_nested_error(nested_error,
+                                                               status=encoding.force_text(response.status_code),
+                                                               source='/included/%s' % identifier))
+                else:
+                    errors.extend(_format_nested_error(error,
+                                                       status=encoding.force_text(response.status_code),
+                                                       source='/data/%s' % field))
             elif isinstance(error, six.string_types):
                 classes = inspect.getmembers(exceptions, inspect.isclass)
                 # DRF sets the `field` to 'detail' for its own exceptions


### PR DESCRIPTION
This makes error messages from `ValidationError` appear as
```
{
    "errors": [
        {
            "detail": "This field is required.", 
            "meta": {
                "source": "/included/authors/1/bio"
            }, 
            "status": "400"
        }, 
        ...
```
instead of the
```
{
    "errors": [
        {
            "authors": [
                {
                    "bio": [
                        "This field is required."
                    ]
                }
            ]
        }, 
        ...
```
Using custom JSON errors is no longer possible with this unfortunately.

I also had to pin `pytest==2.9` and `fake-factory==0.7.4` to make the test suite run.